### PR TITLE
Put mode in module; prefer that over server state

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ Example
 4> GetValue = fun({_K, V}) -> V end.
 5> Pid = fling:manage(Tid, GetKey, GetValue, ModName).
 6> fling:put(Pid, [{a,1},{b,2},{c,3}]).
-7> Mode = fling:mode(Pid).
-8> fling:get(Mode, Tid, ModName, a).
+7> ModeA = fling:mode(Tid, ModName).
+8> fling:get(ModeA, a).
 9> timer:sleep(60*1000).
-10> Mode0 = fling:mode(Pid).
-11> fling:get(Mode0, Tid, ModName, a).
-12> fling:get(Mode, Tid, ModName, a) == fling:get(Mode0, Tid, ModName, a).
+10> ModeB = fling:mode(Tid, ModName).
+11> fling:get(ModeB, a).
+12> fling:get(ModeA, a) == fling:get(ModeB, a).
 ```
 

--- a/src/fling.erl
+++ b/src/fling.erl
@@ -33,6 +33,10 @@
 
 -type fling_mode() :: { ets, Tid :: ets:tid() } | { mg, ModName :: atom() }.
 
+-spec start() -> ok.
+%% @doc Convenience function to start the application from the command line.
+%% 
+%% As in `erl -pz ebin deps/*/ebin -s fling'
 start() ->
     application:ensure_all_started(fling),
     application:start(fling).
@@ -57,9 +61,10 @@ gen_module_name() ->
 
 -spec state( Pid :: pid() ) -> proplists:proplist().
 %% @doc Returns the current state of the cache manager. Keys returned are:
+%%
 %% <ul>
 %% 	<li>`modname' which is the module name if the manager is in `mg' mode</li>
-%% 	<li>`mode' which is the current mode - `ets' or `mg'<li>
+%% 	<li>`mode' which is the current mode - `ets' or `mg'</li>
 %% 	<li>`tid' which is the ETS table identifier</li>
 %% 	<li>`ticks' which is the current tick count</li>
 %% </ul>

--- a/src/fling_ets.erl
+++ b/src/fling_ets.erl
@@ -105,6 +105,7 @@ init([GetKey, GetValue, ModName]) ->
 	      get_value_fun = GetValue },
    {ok, State}.
 
+%% @private
 handle_call(Req, _From, State = #state{ tid = undefined }) ->
    lager:warning("Got call ~p but ETS table has not been given away yet.",
 		 [Req]),
@@ -140,6 +141,7 @@ handle_call(Req, _From, State) ->
    lager:error("Unknown call ~p.", [Req]),
    {reply, whoa, State}.
 
+%% @private
 handle_cast(Req, State = #state{ tid = undefined }) ->
    lager:warning("Got cast ~p but ETS table has not been given away yet.",
 		 [Req]),
@@ -177,6 +179,7 @@ handle_cast(Req, State) ->
    lager:warning("Unknown cast ~p", [Req]),
    {noreply, State}.
 
+%% @private
 handle_info({'ETS-TRANSFER', Tid, From, Options}, State = #state{ secs_per_tick = S, 
 								  tid = undefined }) ->
    lager:debug("Got ETS table ~p from ~p with options ~p", [Tid, From, Options]),
@@ -219,10 +222,12 @@ handle_info(Info, State) ->
    lager:warning("Unknown info ~p", [Info]),
    {noreply, State}.
 
+%% @private
 terminate(_Reason, #state{ modname = M }) ->
    fling_mochiglobal:purge(M),
    ok.
 
+%% @private
 code_change(_Old, State, _Extra) ->
    {ok, State}.
 

--- a/test/fling_promote_writes.erl
+++ b/test/fling_promote_writes.erl
@@ -1,0 +1,51 @@
+%% @doc This test checks for a race condition where a new 
+%% put reverts the cache manager's gen_server into ets mode
+%% but there's a lag between when the put is processed and when
+%% gets into the module stop working.
+%%
+%% This test measures how long the lag is.
+-module(fling_promote_writes).
+-compile([export_all]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+promote_test_() ->
+    {timeout, 60, fun() -> promote() end}.
+
+promote() ->
+    application:load(fling),
+    application:set_env(fling, secs_per_tick, 1),
+    {ok, _} = application:ensure_all_started(fling),
+
+    Tid = ets:new(fling_smoke, []),
+    Data = [ {X, list_to_binary([65+(X rem 26)])} || X <- lists:seq(1,1000) ],
+    true = ets:insert(Tid, Data),
+    ModName = fling:gen_module_name(),
+    Pid = fling:manage(Tid, fun({K, _V}) -> K end, fun({_K, V}) -> V end, ModName),
+
+    {ok, Waits} = wait_until(20, fun() -> is_mode_mg(fling:mode(Tid, ModName)) end),
+    ?debugFmt("waited ~p secs for promotion", [20-Waits]),
+    Mode = fling:mode(Tid, ModName),
+    ?assertEqual(<<"B">>, fling:get(Mode, 1)),
+    %% observe there is nothing up my sleeve...
+    ?assertEqual(undefined, fling:get(Mode, 1001)),
+    fling:put(Pid, {1001, <<"N">>}),
+    {ok, W} = wait_until(20, fun() -> fling:mode_sync(Pid) == fling:mode(Tid, ModName) end),
+    ?debugFmt("waited ~p secs for mode to synchronize", [20-W]),
+    ?assertEqual([{1001, <<"N">>}], fling:get(fling:mode(Tid, ModName), 1001)),
+
+    {ok, W2} = wait_until(20, fun() -> is_mode_mg(fling:mode(Tid, ModName)) end),
+    ?debugFmt("waited ~p secs for another promotion", [20-W2]),
+    ?assertEqual(<<"N">>, fling:get(fling:mode(Tid, ModName), 1001)).
+
+wait_until(0, _F) -> timeout;
+wait_until(Limit, F) ->
+    case F() of
+        true -> {ok, Limit};
+        false -> 
+            timer:sleep(1000),
+            wait_until(Limit - 1, F)
+    end.
+
+is_mode_mg({ets, _}) -> false;
+is_mode_mg({mg, _}) -> true.


### PR DESCRIPTION
Previously, the gen_server was the only place where state information about the cache was available. Now add a mode function to the compiled module so we can avoid a call into the gen_server to get its state.

Fix up tests and add a new state to measure staleness/race conditions around taking new writes after promotion.